### PR TITLE
fix(dotfiles): no idea where `python:{$PATH}` came from

### DIFF
--- a/zshrc.local
+++ b/zshrc.local
@@ -4,8 +4,6 @@
 export NVM_DIR=~/.nvm
 source ~/.nvm/nvm.sh
 
-python:${PATH}
-
 # keep tons of history
 export HISTFILE=~/.zsh_history
 HISTSIZE=10000


### PR DESCRIPTION
merge with master - the deleted line was causing a file not found error in the shell.
